### PR TITLE
feat: add interactive diagnostic flow app

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,37 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['@typescript-eslint', 'react-hooks', 'react-refresh'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'eslint-config-prettier',
+  ],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { prefer: 'type-imports', disallowTypeAnnotations: false },
+    ],
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.dist
+/dist
+.vscode
+.DS_Store
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # protocolo_de_abordaje_tea
-ALGORTIMO-DIAGNÓSTICO. Protocolo de abordaje de los trastornos de aprendizaje
+
+Aplicación web interactiva que reproduce el protocolo de abordaje de los trastornos de aprendizaje mediante un flujo de preguntas y decisiones. Está construida con React, Vite y Tailwind CSS.
+
+## Requisitos previos
+
+- Node.js 18 o superior
+- npm 9 o superior
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Scripts disponibles
+
+- `npm run dev`: inicia el servidor de desarrollo en `http://localhost:5173`.
+- `npm run build`: genera la versión de producción.
+- `npm run preview`: sirve la compilación de producción de forma local.
+- `npm run lint`: ejecuta ESLint sobre el código fuente.
+
+## Estructura principal
+
+- `src/components/FlujoDiagnosticoAprendizaje.tsx`: componente principal con la lógica del flujo.
+- `src/components/ui`: componentes reutilizables de interfaz (`Button`, `Card`).
+- `src/index.css`: estilos base y configuración de Tailwind CSS.
+
+## Licencia
+
+Este proyecto se distribuye con fines educativos.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Protocolo de abordaje TEA</title>
+  </head>
+  <body class="min-h-screen bg-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "protocolo_de_abordaje_tea",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "framer-motion": "^10.18.0",
+    "lucide-react": "^0.323.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^7.1.1",
+    "@typescript-eslint/parser": "^7.1.1",
+    "@vitejs/plugin-react-swc": "^3.6.0",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import FlujoDiagnosticoAprendizaje from '@/components/FlujoDiagnosticoAprendizaje';
+
+function App() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <FlujoDiagnosticoAprendizaje />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/FlujoDiagnosticoAprendizaje.tsx
+++ b/src/components/FlujoDiagnosticoAprendizaje.tsx
@@ -1,0 +1,322 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import type { LucideIcon } from 'lucide-react';
+import { CheckCircle, RotateCw, XCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+type QuestionNode = {
+  type: 'q';
+  text: string;
+  yes: string;
+  no: string;
+  color?: string;
+};
+
+type EndNode = {
+  type: 'end';
+  title: string;
+  color: string;
+  icon?: LucideIcon;
+};
+
+type NodeDefinition = QuestionNode | EndNode;
+
+const NODES = {
+  A: {
+    type: 'q',
+    text: '¿Existe déficit sensorial, afectación neurológica?',
+    yes: 'B',
+    no: 'C',
+  },
+  B: {
+    type: 'q',
+    text: '¿Explican los trastornos de aprendizaje?',
+    yes: 'Z_NO_CONT',
+    no: 'C',
+  },
+  C: { type: 'q', text: '¿Es retraso mental?', yes: 'D', no: 'E' },
+  D: {
+    type: 'q',
+    text: '¿Justifica los problemas de aprendizaje?',
+    yes: 'Z_NO_CONT',
+    no: 'E',
+  },
+  E: {
+    type: 'q',
+    text: '¿Trastorno profundo del desarrollo?',
+    yes: 'F',
+    no: 'G',
+  },
+  F: {
+    type: 'q',
+    text: '¿Justifica los problemas de aprendizaje?',
+    yes: 'Z_NO_CONT',
+    no: 'G',
+  },
+  G: { type: 'q', text: '¿TDAH? ¿Dislexia?', yes: 'H', no: 'I' },
+  H: {
+    type: 'q',
+    text: '¿Justifica los problemas de aprendizaje?',
+    yes: 'Z_NO_CONT',
+    no: 'I',
+  },
+  I: {
+    type: 'q',
+    text: '¿Es el lenguaje adecuado al nivel de desarrollo?',
+    yes: 'K',
+    no: 'J',
+  },
+  J: { type: 'q', text: '¿Problemas de articulación?', yes: 'M', no: 'L' },
+  L: {
+    type: 'end',
+    title: 'Diagnóstico: trastorno de expresión del lenguaje',
+    color: 'bg-emerald-50 border-emerald-300',
+    icon: CheckCircle,
+  },
+  M: {
+    type: 'q',
+    text: '¿Explica el retraso del lenguaje?',
+    yes: 'N',
+    no: 'Z_NO_CONT',
+  },
+  N: {
+    type: 'q',
+    text: '¿Explica los problemas de aprendizaje?',
+    yes: 'O',
+    no: 'Z_NO_CONT',
+  },
+  O: {
+    type: 'end',
+    title: 'Trastorno de la percepción',
+    color: 'bg-emerald-50 border-emerald-300',
+    icon: CheckCircle,
+  },
+  K: {
+    type: 'q',
+    text: '¿Tiene adecuada coordinación?',
+    yes: 'Q',
+    no: 'P',
+  },
+  P: {
+    type: 'q',
+    text: '¿Justifica los problemas de aprendizaje?',
+    yes: 'Z_NO_CONT',
+    no: 'Q',
+  },
+  Q: {
+    type: 'q',
+    text: '¿Las tareas son adecuadas al desarrollo del niño?',
+    yes: 'R',
+    no: 'S',
+  },
+  R: {
+    type: 'end',
+    title: 'Destacar: depresión y/o trastornos de ajuste social o del desarrollo',
+    color: 'bg-amber-50 border-amber-300',
+    icon: CheckCircle,
+  },
+  S: {
+    type: 'q',
+    text: '¿Desajuste de resultados escolares con otras actividades?',
+    yes: 'T',
+    no: 'U',
+  },
+  U: {
+    type: 'end',
+    title: 'Buscar otras causas de retraso del desarrollo',
+    color: 'bg-sky-50 border-sky-300',
+    icon: CheckCircle,
+  },
+  T: {
+    type: 'q',
+    text: '¿Escolarización inadecuada?',
+    yes: 'W',
+    no: 'V',
+  },
+  V: {
+    type: 'end',
+    title: 'Buscar otros diagnósticos',
+    color: 'bg-sky-50 border-sky-300',
+    icon: CheckCircle,
+  },
+  W: {
+    type: 'q',
+    text: 'Diagnóstico adecuado de bajo rendimiento escolar justifica el trastorno del aprendizaje',
+    yes: 'Z_FIN_DIAG',
+    no: 'Z_NO_CONT_DIAG',
+  },
+  Z_NO_CONT: {
+    type: 'end',
+    title: 'No continuar',
+    color: 'bg-rose-50 border-rose-300',
+    icon: XCircle,
+  },
+  Z_NO_CONT_DIAG: {
+    type: 'end',
+    title: 'No continuar diagnóstico',
+    color: 'bg-rose-50 border-rose-300',
+    icon: XCircle,
+  },
+  Z_FIN_DIAG: {
+    type: 'end',
+    title: 'Trastorno del aprendizaje justificado',
+    color: 'bg-emerald-50 border-emerald-300',
+    icon: CheckCircle,
+  },
+} satisfies Record<string, NodeDefinition>;
+
+type NodeKey = keyof typeof NODES;
+type Answer = 'yes' | 'no';
+
+type TrailStep = {
+  id: NodeKey;
+  label: string;
+};
+
+interface BreadcrumbProps {
+  trail: TrailStep[];
+}
+
+function Breadcrumb({ trail }: BreadcrumbProps) {
+  return (
+    <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+      {trail.map((step, index) => (
+        <span key={`${step.id}-${index}`} className="inline-flex items-center gap-2">
+          <span className="rounded-full border border-gray-200 bg-gray-100 px-2 py-0.5">
+            {step.label}
+          </span>
+          {index < trail.length - 1 && <span>→</span>}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface NodeViewProps {
+  nodeId: NodeKey;
+  onAnswer: (answer: Answer) => void;
+}
+
+function NodeView({ nodeId, onAnswer }: NodeViewProps) {
+  const node = NODES[nodeId];
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === 'q') {
+    return (
+      <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
+        <Card className={`border-2 shadow-sm ${node.color ?? ''}`}>
+          <CardContent className="space-y-6 p-6">
+            <h2 className="text-xl font-semibold">{node.text}</h2>
+            <div className="flex gap-3">
+              <Button size="lg" onClick={() => onAnswer('yes')}>
+                Sí
+              </Button>
+              <Button variant="secondary" size="lg" onClick={() => onAnswer('no')}>
+                No
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+    );
+  }
+
+  const Icon = node.icon ?? CheckCircle;
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
+      <Card className={`border-2 shadow-sm ${node.color}`}>
+        <CardContent className="space-y-4 p-6">
+          <div className="flex items-center gap-2">
+            <Icon className="h-6 w-6" />
+            <h2 className="text-xl font-semibold">{node.title}</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Fin de la ruta. Puedes reiniciar o retroceder para explorar otras ramas.
+          </p>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}
+
+export default function FlujoDiagnosticoAprendizaje() {
+  const [current, setCurrent] = useState<NodeKey>('A');
+  const [trail, setTrail] = useState<TrailStep[]>([
+    { id: 'A', label: '¿Existe déficit sensorial, afectación neurológica?' },
+  ]);
+
+  const handleAnswer = (answer: Answer) => {
+    const node = NODES[current];
+    if (!node || node.type !== 'q') {
+      return;
+    }
+
+    const nextKey = (answer === 'yes' ? node.yes : node.no) as NodeKey;
+    const nextNode = NODES[nextKey];
+
+    if (!nextNode) {
+      return;
+    }
+
+    setCurrent(nextKey);
+    setTrail((prev) => [
+      ...prev,
+      {
+        id: nextKey,
+        label: (() => {
+          const responseLabel = `${node.text} → ${answer === 'yes' ? 'Sí' : 'No'}`;
+          return nextNode.type === 'end'
+            ? `${responseLabel} → ${nextNode.title}`
+            : responseLabel;
+        })(),
+      },
+    ]);
+  };
+
+  const restart = () => {
+    setCurrent('A');
+    setTrail([{ id: 'A', label: '¿Existe déficit sensorial, afectación neurológica?' }]);
+  };
+
+  const back = () => {
+    if (trail.length <= 1) {
+      return;
+    }
+    const newTrail = trail.slice(0, -1);
+    const previous = newTrail[newTrail.length - 1];
+    setTrail(newTrail);
+    setCurrent(previous.id);
+  };
+
+  return (
+    <div className="mx-auto space-y-6 p-6 md:p-10">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-bold">Flujo diagnóstico de dificultades de aprendizaje</h1>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={back} disabled={trail.length <= 1}>
+            Retroceder
+          </Button>
+          <Button onClick={restart} className="gap-2">
+            <RotateCw className="h-4 w-4" /> Reiniciar
+          </Button>
+        </div>
+      </div>
+
+      <Breadcrumb trail={trail} />
+
+      <NodeView nodeId={current} onAnswer={handleAnswer} />
+
+      <div className="pt-2 text-sm text-muted-foreground">
+        <p>
+          Esta herramienta guía paso a paso replicando la lógica del diagrama original. Responde{' '}
+          <strong>Sí / No</strong> para avanzar.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type ButtonVariant = 'default' | 'secondary' | 'outline';
+type ButtonSize = 'default' | 'sm' | 'lg';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  outline: 'border border-input bg-background hover:bg-muted hover:text-foreground',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 px-3',
+  lg: 'h-11 px-8 text-base',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(
+        'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Button.displayName = 'Button';

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-background text-foreground shadow-sm', className)}
+      {...props}
+    />
+  ),
+);
+
+Card.displayName = 'Card';
+
+export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6', className)} {...props} />
+  ),
+);
+
+CardContent.displayName = 'CardContent';

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,38 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 16.7% 97.6%;
+    --muted-foreground: 215 19.3% 34.5%;
+
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --accent: 210 20% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 47.4% 11.2%;
+
+    --radius: 0.75rem;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+}
+
+@layer utilities {
+  .text-muted-foreground {
+    color: hsl(var(--muted-foreground));
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | undefined | null | false>) {
+  return inputs.filter(Boolean).join(' ');
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,39 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind project to host the diagnostic flow tool
- implement the FlujoDiagnosticoAprendizaje component that reproduces the decision tree interactions
- add reusable UI primitives and styling configuration for buttons, cards and typography

## Testing
- npm install *(fails: 403 Forbidden when fetching packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dd6b0bf483339815cbc7d0ca5ea6