### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^20.11.20",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^7.1.1",

--- a/src/components/FlujoDiagnosticoAprendizaje.tsx
+++ b/src/components/FlujoDiagnosticoAprendizaje.tsx
@@ -200,15 +200,16 @@ interface NodeViewProps {
 }
 
 function NodeView({ nodeId, onAnswer }: NodeViewProps) {
-  const node = NODES[nodeId];
+  const node: NodeDefinition | undefined = NODES[nodeId];
   if (!node) {
     return null;
   }
 
   if (node.type === 'q') {
+    const questionNode = node as QuestionNode;
     return (
       <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
-        <Card className={`border-2 shadow-sm ${node.color ?? ''}`}>
+        <Card className={`border-2 shadow-sm ${questionNode.color ?? ''}`}>
           <CardContent className="space-y-6 p-6">
             <h2 className="text-xl font-semibold">{node.text}</h2>
             <div className="flex gap-3">

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,6 +8,7 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import path from 'path';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## Summary
- update the Vite config to resolve the src alias without relying on __dirname in ESM mode
- add Node.js type definitions to the TypeScript configuration
- adjust the diagnostic flow component typing so optional colors on question nodes compile cleanly

## Testing
- yarn build *(fails: Yarn cannot install dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e2902fa48333a1197a6bb0bf7b63