### PR TITLE
Fix render build by removing package manager pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "npm@11.4.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- remove the packageManager field from package.json so Render's Yarn 1 installer can run without Corepack

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca3315f97883338d7016efd5cdf9c1